### PR TITLE
sync-upstream: Use --autostash to handle uncommitted changes

### DIFF
--- a/contrib/sync-upstream.sh
+++ b/contrib/sync-upstream.sh
@@ -97,7 +97,7 @@ echo "$BODY"
 echo "-----------------------------------"
 # Create branch from PR commit and create PR
 git checkout master
-git pull
+git pull --autostash
 git checkout -b temp-merge-"$PRNUM"
 
 # Escape single quote


### PR DESCRIPTION
This makes it possible to use sync-upstream with uncommitted changes. (This is in particular helpful when working on the script itself.)

Without this commit, git pull will fail due to the uncommitted changes.