### PR TITLE
Use relative #include paths and tidy header guards (as in upstream)

### DIFF
--- a/include/secp256k1_bppp.h
+++ b/include/secp256k1_bppp.h
@@ -1,5 +1,5 @@
-#ifndef _SECP256K1_BPPP_
-# define _SECP256K1_BPPP_
+#ifndef SECP256K1_BPPP_H
+# define SECP256K1_BPPP_H
 
 # include "secp256k1.h"
 

--- a/include/secp256k1_generator.h
+++ b/include/secp256k1_generator.h
@@ -1,5 +1,5 @@
-#ifndef _SECP256K1_GENERATOR_
-# define _SECP256K1_GENERATOR_
+#ifndef SECP256K1_GENERATOR_H
+# define SECP256K1_GENERATOR_H
 
 # include "secp256k1.h"
 

--- a/include/secp256k1_rangeproof.h
+++ b/include/secp256k1_rangeproof.h
@@ -1,5 +1,5 @@
-#ifndef _SECP256K1_RANGEPROOF_
-# define _SECP256K1_RANGEPROOF_
+#ifndef SECP256K1_RANGEPROOF_H
+# define SECP256K1_RANGEPROOF_H
 
 # include "secp256k1.h"
 # include "secp256k1_generator.h"

--- a/include/secp256k1_surjectionproof.h
+++ b/include/secp256k1_surjectionproof.h
@@ -1,5 +1,5 @@
-#ifndef _SECP256K1_SURJECTIONPROOF_
-#define _SECP256K1_SURJECTIONPROOF_
+#ifndef SECP256K1_SURJECTIONPROOF_H
+#define SECP256K1_SURJECTIONPROOF_H
 
 #include "secp256k1.h"
 #include "secp256k1_rangeproof.h"

--- a/include/secp256k1_whitelist.h
+++ b/include/secp256k1_whitelist.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_WHITELIST_
-#define _SECP256K1_WHITELIST_
+#ifndef SECP256K1_WHITELIST_H
+#define SECP256K1_WHITELIST_H
 
 #include "secp256k1.h"
 

--- a/src/bench_bppp.c
+++ b/src/bench_bppp.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-#include "include/secp256k1_bppp.h"
+#include "../include/secp256k1_bppp.h"
 #include "util.h"
 #include "bench.h"
 

--- a/src/bench_generator.c
+++ b/src/bench_generator.c
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "include/secp256k1_generator.h"
+#include "../include/secp256k1_generator.h"
 #include "util.h"
 #include "bench.h"
 

--- a/src/bench_rangeproof.c
+++ b/src/bench_rangeproof.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-#include "include/secp256k1_rangeproof.h"
+#include "../include/secp256k1_rangeproof.h"
 #include "util.h"
 #include "bench.h"
 

--- a/src/bench_whitelist.c
+++ b/src/bench_whitelist.c
@@ -5,9 +5,9 @@
  **********************************************************************/
 #include <stdio.h>
 
-#include "include/secp256k1.h"
+#include "../include/secp256k1.h"
 
-#include "include/secp256k1_whitelist.h"
+#include "../include/secp256k1_whitelist.h"
 #include "util.h"
 #include "bench.h"
 #include "hash_impl.h"

--- a/src/modules/bppp/bppp_norm_product_impl.h
+++ b/src/modules/bppp/bppp_norm_product_impl.h
@@ -7,15 +7,15 @@
 #ifndef _SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_
 #define _SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_
 
-#include "group.h"
-#include "scalar.h"
-#include "ecmult.h"
-#include "ecmult_gen.h"
-#include "hash.h"
+#include "../../group.h"
+#include "../../scalar.h"
+#include "../../ecmult.h"
+#include "../../ecmult_gen.h"
+#include "../../hash.h"
 
-#include "modules/bppp/main.h"
-#include "modules/bppp/bppp_util.h"
-#include "modules/bppp/bppp_transcript_impl.h"
+#include "../bppp/main.h"
+#include "../bppp/bppp_util.h"
+#include "../bppp/bppp_transcript_impl.h"
 
 /* Computes the inner product of two vectors of scalars
  * with elements starting from offset a and offset b

--- a/src/modules/bppp/bppp_norm_product_impl.h
+++ b/src/modules/bppp/bppp_norm_product_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_
-#define _SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_
+#ifndef SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_H
+#define SECP256K1_MODULE_BPPP_PP_NORM_PRODUCT_H
 
 #include "../../group.h"
 #include "../../scalar.h"

--- a/src/modules/bppp/bppp_transcript_impl.h
+++ b/src/modules/bppp/bppp_transcript_impl.h
@@ -6,8 +6,8 @@
 #ifndef _SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_
 #define _SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_
 
-#include "group.h"
-#include "scalar.h"
+#include "../../group.h"
+#include "../../scalar.h"
 #include "bppp_util.h"
 
 /* Initializes SHA256 with fixed midstate. This midstate was computed by applying

--- a/src/modules/bppp/bppp_transcript_impl.h
+++ b/src/modules/bppp/bppp_transcript_impl.h
@@ -3,8 +3,8 @@
  * Distributed under the MIT software license, see the accompanying   *
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
-#ifndef _SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_
-#define _SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_
+#ifndef SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_H
+#define SECP256K1_MODULE_BPPP_PP_TRANSCRIPT_IMPL_H
 
 #include "../../group.h"
 #include "../../scalar.h"

--- a/src/modules/bppp/bppp_util.h
+++ b/src/modules/bppp/bppp_util.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_MODULE_BPPP_UTIL_
-#define _SECP256K1_MODULE_BPPP_UTIL_
+#ifndef SECP256K1_MODULE_BPPP_UTIL_H
+#define SECP256K1_MODULE_BPPP_UTIL_H
 
 #include "../../field.h"
 #include "../../group.h"

--- a/src/modules/bppp/bppp_util.h
+++ b/src/modules/bppp/bppp_util.h
@@ -7,10 +7,10 @@
 #ifndef _SECP256K1_MODULE_BPPP_UTIL_
 #define _SECP256K1_MODULE_BPPP_UTIL_
 
-#include "field.h"
-#include "group.h"
-#include "hash.h"
-#include "eckey.h"
+#include "../../field.h"
+#include "../../group.h"
+#include "../../hash.h"
+#include "../../eckey.h"
 
 /* Outputs a pair of points, amortizing the parity byte between them
  * Assumes both points' coordinates have been normalized.

--- a/src/modules/bppp/main_impl.h
+++ b/src/modules/bppp/main_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_MODULE_BPPP_MAIN_
-#define _SECP256K1_MODULE_BPPP_MAIN_
+#ifndef SECP256K1_MODULE_BPPP_MAIN_IMPL_H
+#define SECP256K1_MODULE_BPPP_MAIN_IMPL_H
 
 #include "../../../include/secp256k1_bppp.h"
 #include "../../../include/secp256k1_generator.h"

--- a/src/modules/bppp/main_impl.h
+++ b/src/modules/bppp/main_impl.h
@@ -7,13 +7,13 @@
 #ifndef _SECP256K1_MODULE_BPPP_MAIN_
 #define _SECP256K1_MODULE_BPPP_MAIN_
 
-#include "include/secp256k1_bppp.h"
-#include "include/secp256k1_generator.h"
-#include "modules/generator/main_impl.h" /* for generator_{load, save} */
-#include "hash.h"
-#include "util.h"
-#include "modules/bppp/main.h"
-#include "modules/bppp/bppp_norm_product_impl.h"
+#include "../../../include/secp256k1_bppp.h"
+#include "../../../include/secp256k1_generator.h"
+#include "../generator/main_impl.h" /* for generator_{load, save} */
+#include "../../hash.h"
+#include "../../util.h"
+#include "../bppp/main.h"
+#include "../bppp/bppp_norm_product_impl.h"
 
 secp256k1_bppp_generators *secp256k1_bppp_generators_create(const secp256k1_context *ctx, size_t n) {
     secp256k1_bppp_generators *ret;

--- a/src/modules/bppp/tests_impl.h
+++ b/src/modules/bppp/tests_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_MODULE_BPPP_TEST_
-#define _SECP256K1_MODULE_BPPP_TEST_
+#ifndef SECP256K1_MODULE_BPPP_TEST_H
+#define SECP256K1_MODULE_BPPP_TEST_H
 
 #include <stdint.h>
 

--- a/src/modules/bppp/tests_impl.h
+++ b/src/modules/bppp/tests_impl.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#include "include/secp256k1_bppp.h"
+#include "../../../include/secp256k1_bppp.h"
 #include "bppp_norm_product_impl.h"
 #include "bppp_util.h"
 #include "bppp_transcript_impl.h"

--- a/src/modules/extrakeys/hsort.h
+++ b/src/modules/extrakeys/hsort.h
@@ -4,8 +4,8 @@
  * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
  ***********************************************************************/
 
-#ifndef SECP256K1_HSORT_H_
-#define SECP256K1_HSORT_H_
+#ifndef SECP256K1_HSORT_H
+#define SECP256K1_HSORT_H
 
 #include <stddef.h>
 #include <string.h>

--- a/src/modules/extrakeys/hsort_impl.h
+++ b/src/modules/extrakeys/hsort_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
  ***********************************************************************/
 
-#ifndef SECP256K1_HSORT_IMPL_H_
-#define SECP256K1_HSORT_IMPL_H_
+#ifndef SECP256K1_HSORT_IMPL_H
+#define SECP256K1_HSORT_IMPL_H
 
 #include "hsort.h"
 

--- a/src/modules/extrakeys/tests_exhaustive_impl.h
+++ b/src/modules/extrakeys/tests_exhaustive_impl.h
@@ -7,8 +7,8 @@
 #ifndef SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_H
 #define SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_H
 
-#include "src/modules/extrakeys/main_impl.h"
 #include "../../../include/secp256k1_extrakeys.h"
+#include "main_impl.h"
 
 static void test_exhaustive_extrakeys(const secp256k1_context *ctx, const secp256k1_ge* group) {
     secp256k1_keypair keypair[EXHAUSTIVE_TEST_ORDER - 1];

--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_GENERATOR_MAIN
-#define SECP256K1_MODULE_GENERATOR_MAIN
+#ifndef SECP256K1_MODULE_GENERATOR_MAIN_H
+#define SECP256K1_MODULE_GENERATOR_MAIN_H
 
 #include <stdio.h>
 

--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -14,7 +14,7 @@
 #include "../../hash.h"
 #include "../../scalar.h"
 
-#include "modules/generator/pedersen_impl.h"
+#include "../generator/pedersen_impl.h"
 
 /** Alternative generator for secp256k1.
  *  This is the sha256 of 'g' after standard encoding (without compression),

--- a/src/modules/generator/pedersen.h
+++ b/src/modules/generator/pedersen.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_PEDERSEN_H_
-#define _SECP256K1_PEDERSEN_H_
+#ifndef SECP256K1_PEDERSEN_H
+#define SECP256K1_PEDERSEN_H
 
 #include "../../ecmult_gen.h"
 #include "../../group.h"

--- a/src/modules/generator/pedersen_impl.h
+++ b/src/modules/generator/pedersen_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php. *
  ***********************************************************************/
 
-#ifndef _SECP256K1_PEDERSEN_IMPL_H_
-#define _SECP256K1_PEDERSEN_IMPL_H_
+#ifndef SECP256K1_PEDERSEN_IMPL_H
+#define SECP256K1_PEDERSEN_IMPL_H
 
 #include <string.h>
 

--- a/src/modules/generator/tests_impl.h
+++ b/src/modules/generator/tests_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_GENERATOR_TESTS
-#define SECP256K1_MODULE_GENERATOR_TESTS
+#ifndef SECP256K1_MODULE_GENERATOR_TESTS_H
+#define SECP256K1_MODULE_GENERATOR_TESTS_H
 
 #include <string.h>
 #include <stdio.h>

--- a/src/modules/musig/main_impl.h
+++ b/src/modules/musig/main_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_MUSIG_MAIN
-#define SECP256K1_MODULE_MUSIG_MAIN
+#ifndef SECP256K1_MODULE_MUSIG_MAIN_H
+#define SECP256K1_MODULE_MUSIG_MAIN_H
 
 #include "keyagg_impl.h"
 #include "session_impl.h"

--- a/src/modules/rangeproof/borromean.h
+++ b/src/modules/rangeproof/borromean.h
@@ -5,8 +5,8 @@
  **********************************************************************/
 
 
-#ifndef _SECP256K1_BORROMEAN_H_
-#define _SECP256K1_BORROMEAN_H_
+#ifndef SECP256K1_BORROMEAN_H
+#define SECP256K1_BORROMEAN_H
 
 #include "../../scalar.h"
 #include "../../field.h"

--- a/src/modules/rangeproof/borromean_impl.h
+++ b/src/modules/rangeproof/borromean_impl.h
@@ -5,8 +5,8 @@
  **********************************************************************/
 
 
-#ifndef _SECP256K1_BORROMEAN_IMPL_H_
-#define _SECP256K1_BORROMEAN_IMPL_H_
+#ifndef SECP256K1_BORROMEAN_IMPL_H
+#define SECP256K1_BORROMEAN_IMPL_H
 
 #include "../../scalar.h"
 #include "../../field.h"

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_RANGEPROOF_MAIN
-#define SECP256K1_MODULE_RANGEPROOF_MAIN
+#ifndef SECP256K1_MODULE_RANGEPROOF_MAIN_H
+#define SECP256K1_MODULE_RANGEPROOF_MAIN_H
 
 #include "../../group.h"
 

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -9,9 +9,9 @@
 
 #include "../../group.h"
 
-#include "modules/generator/main_impl.h"
-#include "modules/rangeproof/borromean_impl.h"
-#include "modules/rangeproof/rangeproof_impl.h"
+#include "../generator/main_impl.h"
+#include "../rangeproof/borromean_impl.h"
+#include "../rangeproof/rangeproof_impl.h"
 
 int secp256k1_rangeproof_info(const secp256k1_context* ctx, int *exp, int *mantissa,
  uint64_t *min_value, uint64_t *max_value, const unsigned char *proof, size_t plen) {

--- a/src/modules/rangeproof/rangeproof.h
+++ b/src/modules/rangeproof/rangeproof.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_RANGEPROOF_H_
-#define _SECP256K1_RANGEPROOF_H_
+#ifndef SECP256K1_RANGEPROOF_H
+#define SECP256K1_RANGEPROOF_H
 
 #include "../../scalar.h"
 #include "../../group.h"

--- a/src/modules/rangeproof/rangeproof_impl.h
+++ b/src/modules/rangeproof/rangeproof_impl.h
@@ -13,9 +13,9 @@
 #include "../../hash_impl.h"
 #include "../../util.h"
 
-#include "modules/generator/pedersen.h"
-#include "modules/rangeproof/borromean.h"
-#include "modules/rangeproof/rangeproof.h"
+#include "../generator/pedersen.h"
+#include "../rangeproof/borromean.h"
+#include "../rangeproof/rangeproof.h"
 
 SECP256K1_INLINE static void secp256k1_rangeproof_pub_expand(secp256k1_gej *pubs,
  int exp, size_t *rsizes, size_t rings, const secp256k1_ge* genp) {

--- a/src/modules/rangeproof/rangeproof_impl.h
+++ b/src/modules/rangeproof/rangeproof_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_RANGEPROOF_IMPL_H_
-#define _SECP256K1_RANGEPROOF_IMPL_H_
+#ifndef SECP256K1_RANGEPROOF_IMPL_H
+#define SECP256K1_RANGEPROOF_IMPL_H
 
 #include "../../eckey.h"
 #include "../../scalar.h"

--- a/src/modules/rangeproof/tests_impl.h
+++ b/src/modules/rangeproof/tests_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_RANGEPROOF_TESTS
-#define SECP256K1_MODULE_RANGEPROOF_TESTS
+#ifndef SECP256K1_MODULE_RANGEPROOF_TESTS_H
+#define SECP256K1_MODULE_RANGEPROOF_TESTS_H
 
 #include <string.h>
 

--- a/src/modules/recovery/tests_exhaustive_impl.h
+++ b/src/modules/recovery/tests_exhaustive_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
 #define SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
 
-#include "src/modules/recovery/main_impl.h"
+#include "main_impl.h"
 #include "../../../include/secp256k1_recovery.h"
 
 void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {

--- a/src/modules/schnorrsig/tests_exhaustive_impl.h
+++ b/src/modules/schnorrsig/tests_exhaustive_impl.h
@@ -8,7 +8,7 @@
 #define SECP256K1_MODULE_SCHNORRSIG_TESTS_EXHAUSTIVE_H
 
 #include "../../../include/secp256k1_schnorrsig.h"
-#include "src/modules/schnorrsig/main_impl.h"
+#include "main_impl.h"
 
 static const unsigned char invalid_pubkey_bytes[][32] = {
     /* 0 */

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -10,7 +10,7 @@
 #include <string.h>
 
 #if defined HAVE_CONFIG_H
-#include "libsecp256k1-config.h"
+#include "../../libsecp256k1-config.h"
 #endif
 
 #include "../../../include/secp256k1_rangeproof.h"

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -3,8 +3,8 @@
  * Distributed under the MIT software license, see the accompanying   *
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
-#ifndef SECP256K1_MODULE_SURJECTION_MAIN
-#define SECP256K1_MODULE_SURJECTION_MAIN
+#ifndef SECP256K1_MODULE_SURJECTION_MAIN_H
+#define SECP256K1_MODULE_SURJECTION_MAIN_H
 
 #include <assert.h>
 #include <string.h>

--- a/src/modules/surjection/surjection.h
+++ b/src/modules/surjection/surjection.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_SURJECTION_H_
-#define _SECP256K1_SURJECTION_H_
+#ifndef SECP256K1_SURJECTION_H
+#define SECP256K1_SURJECTION_H
 
 #include "../../group.h"
 #include "../../scalar.h"

--- a/src/modules/surjection/surjection_impl.h
+++ b/src/modules/surjection/surjection_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_SURJECTION_IMPL_H_
-#define _SECP256K1_SURJECTION_IMPL_H_
+#ifndef SECP256K1_SURJECTION_IMPL_H
+#define SECP256K1_SURJECTION_IMPL_H
 
 #include <assert.h>
 #include <string.h>

--- a/src/modules/surjection/tests_impl.h
+++ b/src/modules/surjection/tests_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_SURJECTIONPROOF_TESTS
-#define SECP256K1_MODULE_SURJECTIONPROOF_TESTS
+#ifndef SECP256K1_MODULE_SURJECTIONPROOF_TESTS_H
+#define SECP256K1_MODULE_SURJECTIONPROOF_TESTS_H
 
 #include "../../testrand.h"
 #include "../../group.h"

--- a/src/modules/whitelist/main_impl.h
+++ b/src/modules/whitelist/main_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_WHITELIST_MAIN
-#define SECP256K1_MODULE_WHITELIST_MAIN
+#ifndef SECP256K1_MODULE_WHITELIST_MAIN_H
+#define SECP256K1_MODULE_WHITELIST_MAIN_H
 
 #include "../../../include/secp256k1_whitelist.h"
 #include "whitelist_impl.h"

--- a/src/modules/whitelist/tests_impl.h
+++ b/src/modules/whitelist/tests_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef SECP256K1_MODULE_WHITELIST_TESTS
-#define SECP256K1_MODULE_WHITELIST_TESTS
+#ifndef SECP256K1_MODULE_WHITELIST_TESTS_H
+#define SECP256K1_MODULE_WHITELIST_TESTS_H
 
 #include "../../../include/secp256k1_whitelist.h"
 

--- a/src/modules/whitelist/whitelist_impl.h
+++ b/src/modules/whitelist/whitelist_impl.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
-#ifndef _SECP256K1_WHITELIST_IMPL_H_
-#define _SECP256K1_WHITELIST_IMPL_H_
+#ifndef SECP256K1_WHITELIST_IMPL_H
+#define SECP256K1_WHITELIST_IMPL_H
 
 static int secp256k1_whitelist_hash_pubkey(secp256k1_scalar* output, secp256k1_gej* pubkey) {
     unsigned char h[32];

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -33,15 +33,15 @@
 #endif
 
 #ifdef ENABLE_MODULE_GENERATOR
-# include "include/secp256k1_generator.h"
+# include "../include/secp256k1_generator.h"
 #endif
 
 #ifdef ENABLE_MODULE_RANGEPROOF
-# include "include/secp256k1_rangeproof.h"
+# include "../include/secp256k1_rangeproof.h"
 #endif
 
 #ifdef ENABLE_MODULE_ECDSA_S2C
-# include "include/secp256k1_ecdsa_s2c.h"
+# include "../include/secp256k1_ecdsa_s2c.h"
 static void secp256k1_ecdsa_s2c_opening_save(secp256k1_ecdsa_s2c_opening* opening, secp256k1_ge* ge);
 #else
 typedef void secp256k1_ecdsa_s2c_opening;

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -342,15 +342,15 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
 }
 
 #ifdef ENABLE_MODULE_RECOVERY
-#include "src/modules/recovery/tests_exhaustive_impl.h"
+#include "modules/recovery/tests_exhaustive_impl.h"
 #endif
 
 #ifdef ENABLE_MODULE_EXTRAKEYS
-#include "src/modules/extrakeys/tests_exhaustive_impl.h"
+#include "modules/extrakeys/tests_exhaustive_impl.h"
 #endif
 
 #ifdef ENABLE_MODULE_SCHNORRSIG
-#include "src/modules/schnorrsig/tests_exhaustive_impl.h"
+#include "modules/schnorrsig/tests_exhaustive_impl.h"
 #endif
 
 int main(int argc, char** argv) {

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -29,15 +29,15 @@
 #endif
 
 #ifdef ENABLE_MODULE_ECDSA_S2C
-#include "include/secp256k1_ecdsa_s2c.h"
+#include "../include/secp256k1_ecdsa_s2c.h"
 #endif
 
 #ifdef ENABLE_MODULE_ECDSA_ADAPTOR
-#include "include/secp256k1_ecdsa_adaptor.h"
+#include "../include/secp256k1_ecdsa_adaptor.h"
 #endif
 
 #ifdef ENABLE_MODULE_MUSIG
-#include "include/secp256k1_musig.h"
+#include "../include/secp256k1_musig.h"
 #endif
 
 void run_tests(secp256k1_context *ctx, unsigned char *key);


### PR DESCRIPTION
Fixes #208.

This will make it much easier to sync with upstream.

After `./configure --enable-dev-mode`, you can compile manually with `clang -c src/secp256k1.c src/precomputed_*.c -DHAVE_CONFIG_H` to check that the paths are good, at least for the library. I manually inspected `git grep '#include "'` for the rest...

Unfortunately, just removing the `-I` arguments from the Makefile (as in https://github.com/bitcoin-core/secp256k1/pull/1116/commits/40a3473a9d44dc409412e94f70ad0f09bd9da3ac) is not enough to test this because automake adds some standards includes that we can't get rid of. Once we sync with upstream, running a CMake build is a direct way to test this. 