### PR TITLE
bppp: Fix and improve test for invalid sign byte

### DIFF
--- a/src/modules/bppp/tests_impl.h
+++ b/src/modules/bppp/tests_impl.h
@@ -257,7 +257,11 @@ void test_serialize_two_points(void) {
         random_group_element_test(&X);
         random_group_element_test(&R);
         secp256k1_bppp_serialize_points(buf, &X, &R);
-        buf[0] |= 4 + (unsigned char)secp256k1_testrandi64(4, 255);
+
+        buf[0] = 4 + (unsigned char)secp256k1_testrandi64(0, 253);
+        /* Assert that buf[0] is actually invalid. */
+        CHECK(buf[0] != 0x02 && buf[0] != 0x03);
+
         CHECK(!secp256k1_bppp_parse_one_of_points(&X_tmp, buf, 0));
         CHECK(!secp256k1_bppp_parse_one_of_points(&R_tmp, buf, 0));
     }


### PR DESCRIPTION
The test is supposed to create an invalid sign byte. Before this PR, the generated sign byte could in fact be valid due to an overflow.