### PR TITLE
ci: Always define EXPERIMENTAL variable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ env:
   WITH_VALGRIND: yes
   EXTRAFLAGS:
   ### secp256k1 modules
+  EXPERIMENTAL: no
   ECDH: no
   RECOVERY: no
   SCHNORRSIG: no


### PR DESCRIPTION
See the failure here:

https://github.com/BlockstreamResearch/secp256k1-zkp/pull/249/checks?check_run_id=15209841852

I suggest merging this PR and then rebasing sync-upstream on master (and then #249 on sync-upstream). This will give us a bit more meaningful CI output for now when working on sync-upstream, even though the Linux tasks still don't work.