### PR TITLE
musig: change test vector generation code shebang from python to python3

### DIFF
--- a/contrib/musig2-vectors.py
+++ b/contrib/musig2-vectors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import json


### PR DESCRIPTION
The linter included in the Bitcoin Core and Elements test framework requires python3.