### PR TITLE
Schnorr (Incremental) Half Aggregation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ env:
   MUSIG: 'no'
   ECDSAADAPTOR: 'no'
   BPPP: 'no'
+  SCHNORRSIG_HALFAGG: 'no'
   ### test options
   SECP256K1_TEST_ITERS:
   BENCH: 'yes'
@@ -78,14 +79,14 @@ jobs:
       matrix:
         configuration:
           - env_vars: { WIDEMUL: 'int64',  RECOVERY: 'yes' }
-          - env_vars: { WIDEMUL: 'int64',                   ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes',  RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes' }
+          - env_vars: { WIDEMUL: 'int64',                   ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes',  RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes'}
           - env_vars: { WIDEMUL: 'int128' }
           - env_vars: { WIDEMUL: 'int128_struct',                                           ELLSWIFT: 'yes' }
           - env_vars: { WIDEMUL: 'int128', RECOVERY: 'yes',              SCHNORRSIG: 'yes', ELLSWIFT: 'yes' }
-          - env_vars: { WIDEMUL: 'int128',                  ECDH: 'yes', SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes'}
+          - env_vars: { WIDEMUL: 'int128',                  ECDH: 'yes', SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes'}
           - env_vars: { WIDEMUL: 'int128', ASM: 'x86_64',                                   ELLSWIFT: 'yes' }
-          - env_vars: {                    RECOVERY: 'yes',              SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes'}
-          - env_vars: { CTIMETESTS: 'no',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', CPPFLAGS: '-DVERIFY' }
+          - env_vars: {                    RECOVERY: 'yes',              SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes'}
+          - env_vars: { CTIMETESTS: 'no',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes', CPPFLAGS: '-DVERIFY' }
           - env_vars: { BUILD: 'distcheck', WITH_VALGRIND: 'no', CTIMETESTS: 'no', BENCH: 'no' }
           - env_vars: { CPPFLAGS: '-DDETERMINISTIC' }
           - env_vars: { CFLAGS: '-O0', CTIMETESTS: 'no' }
@@ -156,6 +157,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CC: ${{ matrix.cc }}
 
     steps:
@@ -208,6 +210,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
 
     steps:
@@ -267,6 +270,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
 
     steps:
@@ -320,6 +324,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
 
     strategy:
@@ -383,6 +388,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
 
     steps:
@@ -443,6 +449,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
       SECP256K1_TEST_ITERS: 2
 
@@ -502,6 +509,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
       CFLAGS: '-fsanitize=undefined,address -g'
       UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
@@ -567,6 +575,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'yes'
       CC: 'clang'
       SECP256K1_TEST_ITERS: 32
@@ -622,6 +631,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
       CTIMETESTS: 'no'
 
     strategy:
@@ -678,15 +688,15 @@ jobs:
       fail-fast: false
       matrix:
         env_vars:
-          - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes' }
+          - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes' }
           - { WIDEMUL: 'int128_struct', ECMULTGENPRECISION: 2, ECMULTWINDOW: 4 }
-          - { WIDEMUL: 'int128',                  ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes' }
+          - { WIDEMUL: 'int128',                  ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes' }
           - { WIDEMUL: 'int128', RECOVERY: 'yes' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', CC: 'gcc' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes',            WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', CC: 'gcc', WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', CPPFLAGS: '-DVERIFY', CTIMETESTS: 'no' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes', CC: 'gcc' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes',           WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes', CC: 'gcc', WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', ECDSA_S2C: 'yes', RANGEPROOF: 'yes', WHITELIST: 'yes', GENERATOR: 'yes', MUSIG: 'yes', ECDSAADAPTOR: 'yes', BPPP: 'yes', SCHNORRSIG_HALFAGG: 'yes', CPPFLAGS: '-DVERIFY', CTIMETESTS: 'no' }
           - BUILD: 'distcheck'
 
     steps:
@@ -805,6 +815,7 @@ jobs:
       MUSIG: 'yes'
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
+      SCHNORRSIG_HALFAGG: 'yes'
 
     steps:
       - name: Checkout

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,10 @@ EXTRA_DIST += src/wycheproof/WYCHEPROOF_COPYING
 EXTRA_DIST += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
 EXTRA_DIST += tools/tests_wycheproof_generate.py
 
+if ENABLE_MODULE_SCHNORRSIG_HALFAGG
+include src/modules/schnorrsig_halfagg/Makefile.am.include
+endif
+
 if ENABLE_MODULE_BPPP
 include src/modules/bppp/Makefile.am.include
 endif

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -13,7 +13,7 @@ print_environment() {
     # does not rely on bash.
     for var in WERROR_CFLAGS MAKEFLAGS BUILD \
             ECMULTWINDOW ECMULTGENPRECISION ASM WIDEMUL WITH_VALGRIND EXTRAFLAGS \
-            EXPERIMENTAL ECDH RECOVERY SCHNORRSIG ELLSWIFT \
+            EXPERIMENTAL ECDH RECOVERY SCHNORRSIG SCHNORRSIG_HALFAGG ELLSWIFT \
             ECDSA_S2C GENERATOR RANGEPROOF WHITELIST MUSIG ECDSAADAPTOR BPPP \
             SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETESTS\
             EXAMPLES \
@@ -82,6 +82,7 @@ esac
     --enable-module-rangeproof="$RANGEPROOF" --enable-module-whitelist="$WHITELIST" --enable-module-generator="$GENERATOR" \
     --enable-module-schnorrsig="$SCHNORRSIG"  --enable-module-musig="$MUSIG" --enable-module-ecdsa-adaptor="$ECDSAADAPTOR" \
     --enable-module-schnorrsig="$SCHNORRSIG" \
+    --enable-module-schnorrsig-halfagg="$SCHNORRSIG_HALFAGG" \
     --enable-examples="$EXAMPLES" \
     --enable-ctime-tests="$CTIMETESTS" \
     --with-valgrind="$WITH_VALGRIND" \

--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,10 @@ AC_ARG_ENABLE(module_schnorrsig,
     AS_HELP_STRING([--enable-module-schnorrsig],[enable schnorrsig module [default=yes]]), [],
     [SECP_SET_DEFAULT([enable_module_schnorrsig], [yes], [yes])])
 
+AC_ARG_ENABLE(module_schnorrsig_halfagg,
+    AS_HELP_STRING([--enable-module-schnorrsig-halfagg],[enable schnorrsig half-aggregation module (experimental) [default=no]]), [],
+    [SECP_SET_DEFAULT([enable_module_schnorrsig_halfagg], [no], [yes])])
+
 AC_ARG_ENABLE(module_ellswift,
     AS_HELP_STRING([--enable-module-ellswift],[enable ElligatorSwift module [default=yes]]), [],
     [SECP_SET_DEFAULT([enable_module_ellswift], [yes], [yes])])
@@ -445,6 +449,11 @@ SECP_CFLAGS="$SECP_CFLAGS $WERROR_CFLAGS"
 
 # Processing must be done in a reverse topological sorting of the dependency graph
 # (dependent module first).
+if test x"$enable_module_schnorrsig_halfagg" = x"yes"; then
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_SCHNORRSIG_HALFAGG=1"
+  enable_module_schnorrsig=yes
+fi
+
 if test x"$enable_module_bppp" = x"yes"; then
   if test x"$enable_module_generator" = x"no"; then
     AC_MSG_ERROR([Module dependency error: You have disabled the generator module explicitly, but it is required by the bppp module.])
@@ -497,7 +506,6 @@ if test x"$enable_module_generator" = x"yes"; then
   SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_GENERATOR=1"
 fi
 
-
 if test x"$enable_module_ellswift" = x"yes"; then
   SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_ELLSWIFT=1"
 fi
@@ -544,6 +552,9 @@ else
   # module (which automatically enables the module dependencies) we want to
   # print an error for the dependent module, not the module dependency. Hence,
   # we first test dependent modules.
+  if test x"$enable_module_schnorrsig_halfagg" = x"yes"; then
+    AC_MSG_ERROR([Schnorrsig Half-Aggregation module is experimental. Use --enable-experimental to allow.])
+  fi
   if test x"$enable_module_bppp" = x"yes"; then
     AC_MSG_ERROR([Bulletproofs++ module is experimental. Use --enable-experimental to allow.])
   fi
@@ -599,6 +610,7 @@ AM_CONDITIONAL([ENABLE_MODULE_MUSIG], [test x"$enable_module_musig" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_ECDSA_S2C], [test x"$enable_module_ecdsa_s2c" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_ECDSA_ADAPTOR], [test x"$enable_module_ecdsa_adaptor" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_BPPP], [test x"$enable_module_bppp" = x"yes"])
+AM_CONDITIONAL([ENABLE_MODULE_SCHNORRSIG_HALFAGG], [test x"$enable_module_schnorrsig_halfagg" = x"yes"])
 AM_CONDITIONAL([USE_REDUCED_SURJECTION_PROOF_SIZE], [test x"$use_reduced_surjection_proof_size" = x"yes"])
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$enable_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm32"])
@@ -638,18 +650,19 @@ echo "  module musig            = $enable_module_musig"
 echo "  module ecdsa-s2c        = $enable_module_ecdsa_s2c"
 echo "  module ecdsa-adaptor    = $enable_module_ecdsa_adaptor"
 echo "  module bppp             = $enable_module_bppp"
+echo "  module schnorrsig-halfagg = $enable_module_schnorrsig_halfagg"
 echo
-echo "  asm                     = $set_asm"
-echo "  ecmult window size      = $set_ecmult_window"
-echo "  ecmult gen prec. bits   = $set_ecmult_gen_precision"
+echo "  asm                       = $set_asm"
+echo "  ecmult window size        = $set_ecmult_window"
+echo "  ecmult gen prec. bits     = $set_ecmult_gen_precision"
 # Hide test-only options unless they're used.
 if test x"$set_widemul" != xauto; then
-echo "  wide multiplication     = $set_widemul"
+echo "  wide multiplication       = $set_widemul"
 fi
 echo
-echo "  valgrind                = $enable_valgrind"
-echo "  CC                      = $CC"
-echo "  CPPFLAGS                = $CPPFLAGS"
-echo "  SECP_CFLAGS             = $SECP_CFLAGS"
-echo "  CFLAGS                  = $CFLAGS"
-echo "  LDFLAGS                 = $LDFLAGS"
+echo "  valgrind                  = $enable_valgrind"
+echo "  CC                        = $CC"
+echo "  CPPFLAGS                  = $CPPFLAGS"
+echo "  SECP_CFLAGS               = $SECP_CFLAGS"
+echo "  CFLAGS                    = $CFLAGS"
+echo "  LDFLAGS                   = $LDFLAGS"

--- a/include/secp256k1_schnorrsig_halfagg.h
+++ b/include/secp256k1_schnorrsig_halfagg.h
@@ -1,0 +1,107 @@
+#ifndef SECP256K1_SCHNORRSIG_HALFAGG_H
+#define SECP256K1_SCHNORRSIG_HALFAGG_H
+
+#include "secp256k1.h"
+#include "secp256k1_extrakeys.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** Incrementally (Half-)Aggregate a sequence of Schnorr
+ *  signatures to an existing half-aggregate signature.
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:           ctx: a secp256k1 context object.
+ *  In/Out:      aggsig: pointer to the serialized aggregate signature
+ *                       that is input. The first 32*(n_before+1) of this
+ *                       array should hold the input aggsig. It will be
+ *                       overwritten by the new serialized aggregate signature.
+ *                       It should be large enough for that, see aggsig_len.
+ *           aggsig_len: size of aggsig array in bytes.
+ *                       Should be large enough to hold the new
+ *                       serialized aggregate signature, i.e.,
+ *                       should satisfy aggsig_size >= 32*(n_before+n_new+1).
+ *                       It will be overwritten to be the exact size of the
+ *                       resulting aggsig.
+ *  In:     all_pubkeys: Array of (n_before + n_new) many x-only public keys,
+ *                       including both the ones for the already aggregated signature
+ *                       and the ones for the signatures that should be added.
+ *                       Can only be NULL if n_before + n_new is 0.
+ *           all_msgs32: Array of (n_before + n_new) many 32-byte messages,
+ *                       including both the ones for the already aggregated signature
+ *                       and the ones for the signatures that should be added.
+ *                       Can only be NULL if n_before + n_new is 0.
+ *           new_sigs64: Array of n_new many 64-byte signatures, containing the new
+ *                       signatures that should be added. Can only be NULL if n_new is 0.
+ *             n_before: Number of signatures that have already been aggregated
+ *                       in the input aggregate signature.
+ *                n_new: Number of signatures that should now be added
+ *                       to the aggregate signature.
+ */
+SECP256K1_API int secp256k1_schnorrsig_inc_aggregate(
+    const secp256k1_context *ctx,
+    unsigned char *aggsig,
+    size_t *aggsig_len,
+    const secp256k1_xonly_pubkey* all_pubkeys,
+    const unsigned char *all_msgs32,
+    const unsigned char *new_sigs64,
+    size_t n_before,
+    size_t n_new
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+
+/** (Half-)Aggregate a sequence of Schnorr signatures.
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:           ctx: a secp256k1 context object.
+ *  Out:         aggsig: pointer to an array of aggsig_len many bytes to
+ *                       store the serialized aggregate signature.
+ *  In/Out:  aggsig_len: size of the aggsig array that is passed in bytes;
+ *                       will be overwritten to be the exact size of aggsig.
+ *  In:         pubkeys: Array of n many x-only public keys.
+ *                       Can only be NULL if n is 0.
+ *               msgs32: Array of n many 32-byte messages.
+ *                       Can only be NULL if n is 0.
+ *               sigs64: Array of n many 64-byte signatures.
+ *                       Can only be NULL if n is 0.
+ *                    n: number of signatures to be aggregated.
+ */
+SECP256K1_API int secp256k1_schnorrsig_aggregate(
+    const secp256k1_context *ctx,
+    unsigned char *aggsig,
+    size_t *aggsig_len,
+    const secp256k1_xonly_pubkey *pubkeys,
+    const unsigned char *msgs32,
+    const unsigned char *sigs64,
+    size_t n
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+
+/** Verify a (Half-)aggregate Schnorr signature.
+ *
+ *  Returns:          1: correct signature.
+ *                    0: incorrect signature.
+ *  Args:           ctx: a secp256k1 context object.
+ *  In:         pubkeys: Array of n many x-only public keys. Can only be NULL if n is 0.
+ *               msgs32: Array of n many 32-byte messages. Can only be NULL if n is 0.
+ *                    n: number of signatures to that have been aggregated.
+ *               aggsig: Pointer to an array of aggsig_size many bytes
+ *                       containing the serialized aggregate
+ *                       signature to be verified.
+ *           aggsig_len: Size of the aggregate signature in bytes.
+ *                       Should be aggsig_len = 32*(n+1)
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorrsig_aggverify(
+    const secp256k1_context *ctx,
+    const secp256k1_xonly_pubkey *pubkeys,
+    const unsigned char *msgs32,
+    size_t n,
+    const unsigned char *aggsig,
+    size_t aggsig_len
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(5);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECP256K1_SCHNORRSIG_HALFAGG_H */

--- a/src/modules/schnorrsig_halfagg/Makefile.am.include
+++ b/src/modules/schnorrsig_halfagg/Makefile.am.include
@@ -1,0 +1,3 @@
+include_HEADERS += include/secp256k1_schnorrsig_halfagg.h
+noinst_HEADERS += src/modules/schnorrsig_halfagg/main_impl.h
+noinst_HEADERS += src/modules/schnorrsig_halfagg/tests_impl.h

--- a/src/modules/schnorrsig_halfagg/main_impl.h
+++ b/src/modules/schnorrsig_halfagg/main_impl.h
@@ -1,0 +1,202 @@
+#ifndef SECP256K1_MODULE_SCHNORRSIG_HALFAGG_MAIN_H
+#define SECP256K1_MODULE_SCHNORRSIG_HALFAGG_MAIN_H
+
+#include "../../../include/secp256k1.h"
+#include "../../../include/secp256k1_schnorrsig.h"
+#include "../../../include/secp256k1_schnorrsig_halfagg.h"
+#include "../../hash.h"
+
+/* Initializes SHA256 with fixed midstate. This midstate was computed by applying
+ * SHA256 to SHA256("HalfAgg/randomizer")||SHA256("HalfAgg/randomizer"). */
+void secp256k1_schnorrsig_sha256_tagged_aggregation(secp256k1_sha256 *sha) {
+   secp256k1_sha256_initialize(sha);
+    sha->s[0] = 0xd11f5532ul;
+    sha->s[1] = 0xfa57f70ful;
+    sha->s[2] = 0x5db0d728ul;
+    sha->s[3] = 0xf806ffe1ul;
+    sha->s[4] = 0x1d4db069ul;
+    sha->s[5] = 0xb4d587e1ul;
+    sha->s[6] = 0x50451c2aul;
+    sha->s[7] = 0x10fb63e9ul;
+
+    sha->bytes = 64;
+}
+
+int secp256k1_schnorrsig_inc_aggregate(const secp256k1_context *ctx, unsigned char *aggsig, size_t *aggsig_len, const secp256k1_xonly_pubkey *all_pubkeys, const unsigned char *all_msgs32, const unsigned char *new_sigs64, size_t n_before, size_t n_new) {
+    size_t i;
+    size_t n;
+    secp256k1_sha256 hash;
+    secp256k1_scalar s;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(aggsig != NULL);
+    ARG_CHECK(aggsig_len != NULL);
+    ARG_CHECK(new_sigs64 != NULL || n_new == 0);
+
+    /* Check that aggsig_len is large enough, i.e. aggsig_len >= 32*(n+1) */
+    n = n_before + n_new;
+    ARG_CHECK(n >= n_before);
+    ARG_CHECK(all_pubkeys != NULL || n == 0);
+    ARG_CHECK(all_msgs32 != NULL || n == 0);
+    if ((*aggsig_len / 32) <= 0 || ((*aggsig_len / 32) - 1) < n) {
+        return 0;
+    }
+
+    /* Prepare hash with common prefix. The prefix is the tag and       */
+    /* r_0 || pk_0 || m_0 || .... ||  r_{n'-1} || pk_{n'-1} || m_{n'-1} */
+    /* where n' = n_before                                              */
+    secp256k1_schnorrsig_sha256_tagged_aggregation(&hash);
+    for (i = 0; i < n_before; ++i) {
+        /* serialize pk_i */
+        unsigned char pk_ser[32];
+        if (!secp256k1_xonly_pubkey_serialize(ctx, pk_ser, &all_pubkeys[i])) {
+            return 0;
+        }
+        /* write r_i */
+        secp256k1_sha256_write(&hash, &aggsig[i*32], 32);
+        /* write pk_i */
+        secp256k1_sha256_write(&hash, pk_ser, 32);
+        /* write m_i*/
+        secp256k1_sha256_write(&hash, &all_msgs32[i*32], 32);
+    }
+
+    /* Compute s = s_old + sum_{i = n_before}^{n} z_i*s_i */
+    /* where s_old = 0 if n_before = 0 */
+    secp256k1_scalar_set_int(&s, 0);
+    if (n_before > 0) secp256k1_scalar_set_b32(&s, &aggsig[n_before*32], NULL);
+    for (i = n_before; i < n; ++i) {
+        unsigned char pk_ser[32];
+        unsigned char hashoutput[32];
+        secp256k1_sha256 hashcopy;
+        secp256k1_scalar si;
+        secp256k1_scalar zi;
+
+        /* Step 0: Serialize pk_i into pk_ser   */
+        if (!secp256k1_xonly_pubkey_serialize(ctx, pk_ser, &all_pubkeys[i])) {
+            return 0;
+        }
+
+        /* Step 1: z_i = TaggedHash(...) */
+        /* 1.a) Write into hash r_i, pk_i, m_i, r_i */
+        secp256k1_sha256_write(&hash, &new_sigs64[(i-n_before)*64], 32);
+        secp256k1_sha256_write(&hash, pk_ser, 32);
+        secp256k1_sha256_write(&hash, &all_msgs32[i*32], 32);
+        /* 1.b) Copy the hash */
+        hashcopy = hash;
+        /* 1.c) Finalize the copy to get zi*/
+        secp256k1_sha256_finalize(&hashcopy, hashoutput);
+        /* Note: No need to check overflow, comes from hash */
+        secp256k1_scalar_set_b32(&zi, hashoutput, NULL);
+
+        /* Step 2: s := s + zi*si */
+        /* except if i == 0, then zi = 1 implicitly */
+        secp256k1_scalar_set_b32(&si, &new_sigs64[(i-n_before)*64+32], NULL);
+        if (i != 0) secp256k1_scalar_mul(&si, &si, &zi);
+        secp256k1_scalar_add(&s, &s, &si);
+    }
+
+    /* copy new rs into aggsig */
+    for (i = n_before; i < n; ++i) {
+        memcpy(&aggsig[i*32], &new_sigs64[(i-n_before)*64], 32);
+    }
+    /* copy new s into aggsig */
+    secp256k1_scalar_get_b32(&aggsig[n*32], &s);
+    *aggsig_len = 32 * (1 + n);
+    return 1;
+}
+
+int secp256k1_schnorrsig_aggregate(const secp256k1_context *ctx, unsigned char *aggsig, size_t *aggsig_len, const secp256k1_xonly_pubkey *pubkeys, const unsigned char *msgs32, const unsigned char *sigs64, size_t n) {
+    return secp256k1_schnorrsig_inc_aggregate(ctx, aggsig, aggsig_len, pubkeys, msgs32, sigs64, 0, n);
+}
+
+int secp256k1_schnorrsig_aggverify(const secp256k1_context *ctx, const secp256k1_xonly_pubkey *pubkeys, const unsigned char *msgs32, size_t n, const unsigned char *aggsig, size_t aggsig_len) {
+    size_t i;
+    secp256k1_gej lhs, rhs;
+    secp256k1_scalar s;
+    secp256k1_sha256 hash;
+    int overflow;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(pubkeys != NULL || n == 0);
+    ARG_CHECK(msgs32 != NULL || n == 0);
+    ARG_CHECK(aggsig != NULL);
+    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+
+    /* Check that aggsig_len is correct, i.e., aggsig_len = 32*(n+1) */
+    if ((aggsig_len / 32) <= 0 || ((aggsig_len / 32)-1) != n || (aggsig_len % 32) != 0) {
+        return 0;
+    }
+
+    /* Compute the rhs:               */
+    /* Set rhs = 0                    */
+    /* For each i in 0,.., n-1, do:   */
+    /*     (1) z_i = TaggedHash(...)  */
+    /*     (2) T_i = R_i+e_i*P_i      */
+    /*     (3) rhs = rhs + z_i*T_i    */
+    secp256k1_gej_set_infinity(&rhs);
+    secp256k1_schnorrsig_sha256_tagged_aggregation(&hash);
+    for (i = 0; i < n; ++i) {
+        secp256k1_fe rx;
+        secp256k1_ge rp, pp;
+        secp256k1_scalar ei;
+        secp256k1_gej ppj, ti;
+
+        unsigned char pk_ser[32];
+        unsigned char hashoutput[32];
+        secp256k1_sha256 hashcopy;
+        secp256k1_scalar zi;
+
+        /* Step 0: Serialize pk_i into pk_ser   */
+        /* We need that in Step 1 and in Step 2 */
+        if (!secp256k1_xonly_pubkey_load(ctx, &pp, &pubkeys[i])) {
+            return 0;
+        }
+        secp256k1_fe_get_b32(pk_ser, &pp.x);
+
+        /* Step 1: z_i = TaggedHash(...) */
+        /* 1.a) Write into hash r_i, pk_i, m_i, r_i */
+        secp256k1_sha256_write(&hash, &aggsig[i*32], 32);
+        secp256k1_sha256_write(&hash, pk_ser, 32);
+        secp256k1_sha256_write(&hash, &msgs32[i*32], 32);
+        /* 1.b) Copy the hash */
+        hashcopy = hash;
+        /* 1.c) Finalize the copy to get zi*/
+        secp256k1_sha256_finalize(&hashcopy, hashoutput);
+        secp256k1_scalar_set_b32(&zi, hashoutput, NULL);
+
+        /* Step 2: T_i = R_i+e_i*P_i */
+        /* 2.a) R_i = lift_x(int(r_i)); fail if that fails */
+        if (!secp256k1_fe_set_b32_limit(&rx, &aggsig[i*32])) {
+            return 0;
+        }
+        if (!secp256k1_ge_set_xo_var(&rp, &rx, 0)) {
+            return 0;
+        }
+
+        /* 2.b) e_i = int(hash_{BIP0340/challenge}(bytes(r_i) || pk_i || m_i)) mod n */
+        secp256k1_schnorrsig_challenge(&ei, &aggsig[i*32], &msgs32[i*32], 32, pk_ser);
+        secp256k1_gej_set_ge(&ppj, &pp);
+        /* 2.c) T_i = R_i + e_i*P_i */
+        secp256k1_ecmult(&ti, &ppj, &ei, NULL);
+        secp256k1_gej_add_ge_var(&ti, &ti, &rp, NULL);
+
+        /* Step 3: rhs = rhs + zi*T_i  */
+        /* Note that if i == 0, then zi = 1 implicitly */
+        if (i != 0) secp256k1_ecmult(&ti, &ti, &zi, NULL);
+        secp256k1_gej_add_var(&rhs, &rhs, &ti, NULL);
+    }
+
+    /* Compute the lhs as lhs = s*G */
+    secp256k1_scalar_set_b32(&s, &aggsig[n*32], &overflow);
+    if (overflow) {
+        return 0;
+    }
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &lhs, &s);
+
+    /* Check that lhs == rhs */
+    secp256k1_gej_neg(&lhs, &lhs);
+    secp256k1_gej_add_var(&lhs, &lhs, &rhs, NULL);
+    return secp256k1_gej_is_infinity(&lhs);
+}
+
+#endif

--- a/src/modules/schnorrsig_halfagg/tests_impl.h
+++ b/src/modules/schnorrsig_halfagg/tests_impl.h
@@ -1,0 +1,338 @@
+#ifndef SECP256K1_MODULE_SCHNORRSIG_HALFAGG_TESTS_H
+#define SECP256K1_MODULE_SCHNORRSIG_HALFAGG_TESTS_H
+
+#include "../../../include/secp256k1_schnorrsig_halfagg.h"
+
+#define N_MAX 50
+
+/* We test that the hash initialized by secp256k1_schnorrsig_sha256_tagged_aggregate
+ * has the expected state. */
+void test_schnorrsig_sha256_tagged_aggregate(void) {
+    unsigned char tag[18] = "HalfAgg/randomizer";
+    secp256k1_sha256 sha;
+    secp256k1_sha256 sha_optimized;
+
+    secp256k1_sha256_initialize_tagged(&sha, (unsigned char *) tag, sizeof(tag));
+    secp256k1_schnorrsig_sha256_tagged_aggregation(&sha_optimized);
+    test_sha256_eq(&sha, &sha_optimized);
+}
+
+/* Create n many x-only pubkeys and sigs for random messages */
+void test_schnorrsig_aggregate_input_helper(secp256k1_xonly_pubkey *pubkeys, unsigned char *msgs32, unsigned char *sigs64, size_t n) {
+    size_t i;
+    for (i = 0; i < n; ++i) {
+        unsigned char sk[32];
+        secp256k1_keypair keypair;
+        secp256k1_testrand256(sk);
+        secp256k1_testrand256(&msgs32[i*32]);
+
+        CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+        CHECK(secp256k1_keypair_xonly_pub(CTX, &pubkeys[i], NULL, &keypair));
+        CHECK(secp256k1_schnorrsig_sign(CTX, &sigs64[i*64], &msgs32[i*32], &keypair, NULL));
+    }
+}
+
+/* In this test we create a bunch of Schnorr signatures,
+ * aggregate some of them in one shot, and then
+ * aggregate the others incrementally to the already aggregated ones.
+ * The aggregate signature should verify after both steps. */
+void test_schnorrsig_aggregate(void) {
+    secp256k1_xonly_pubkey pubkeys[N_MAX];
+    unsigned char msgs32[N_MAX*32];
+    unsigned char sigs64[N_MAX*64];
+    unsigned char aggsig[32*(N_MAX + 1) + 17];
+    size_t aggsig_len = sizeof(aggsig);
+
+    size_t n = secp256k1_testrand_int(N_MAX + 1);
+    size_t n_initial = secp256k1_testrand_int(n + 1);
+    size_t n_new = n - n_initial;
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+
+    /* Aggregate the first n_initial of them */
+    CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, sigs64, n_initial));
+    /* Make sure that the aggregate signature verifies */
+    CHECK(aggsig_len == 32*(n_initial + 1));
+    CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n_initial, aggsig, aggsig_len));
+    /* Aggregate the remaining n_new many signatures to the already existing ones */
+    aggsig_len = sizeof(aggsig);
+    secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new);
+    /* Make sure that the aggregate signature verifies */
+    CHECK(aggsig_len == 32*(n + 1));
+    CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len));
+
+    /* Check that a direct aggregation of the n sigs yields an identical aggsig */
+    {
+        unsigned char aggsig2[sizeof(aggsig)];
+        size_t aggsig_len2 = sizeof(aggsig2);
+        CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig2, &aggsig_len2, pubkeys, msgs32, sigs64, n));
+        CHECK(aggsig_len == aggsig_len2);
+        CHECK(secp256k1_memcmp_var(aggsig, aggsig2, aggsig_len) == 0);
+    }
+}
+
+/* This tests the verification test vectors from
+ * https://github.com/BlockstreamResearch/cross-input-aggregation/blob/master/hacspec-halfagg/tests/tests.rs#L78 . */
+void test_schnorrsig_aggverify_spec_vectors(void) {
+    /* Test vector 0 */
+    {
+        size_t n = 0;
+        const unsigned char aggsig[32] = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+        size_t aggsig_len = sizeof(aggsig);
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, NULL, NULL, n, aggsig, aggsig_len));
+    }
+    /* Test vector 1 */
+    {
+        size_t n = 1;
+        const unsigned char pubkeys_ser[1*32] = {
+            0x1b, 0x84, 0xc5, 0x56, 0x7b, 0x12, 0x64, 0x40,
+            0x99, 0x5d, 0x3e, 0xd5, 0xaa, 0xba, 0x05, 0x65,
+            0xd7, 0x1e, 0x18, 0x34, 0x60, 0x48, 0x19, 0xff,
+            0x9c, 0x17, 0xf5, 0xe9, 0xd5, 0xdd, 0x07, 0x8f
+        };
+        secp256k1_xonly_pubkey pubkeys[1];
+        const unsigned char msgs32[1*32] = {
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02
+        };
+        const unsigned char aggsig[1*32+32] = {
+            0xb0, 0x70, 0xaa, 0xfc, 0xea, 0x43, 0x9a, 0x4f,
+            0x6f, 0x1b, 0xbf, 0xc2, 0xeb, 0x66, 0xd2, 0x9d,
+            0x24, 0xb0, 0xca, 0xb7, 0x4d, 0x6b, 0x74, 0x5c,
+            0x3c, 0xfb, 0x00, 0x9c, 0xc8, 0xfe, 0x4a, 0xa8,
+            0x0e, 0x06, 0x6c, 0x34, 0x81, 0x99, 0x36, 0x54,
+            0x9f, 0xf4, 0x9b, 0x6f, 0xd4, 0xd4, 0x1e, 0xdf,
+            0xc4, 0x01, 0xa3, 0x67, 0xb8, 0x7d, 0xdd, 0x59,
+            0xfe, 0xe3, 0x81, 0x77, 0x96, 0x1c, 0x22, 0x5f,
+        };
+        size_t aggsig_len = sizeof(aggsig);
+        size_t i;
+        for (i = 0; i < n; ++i) {
+            CHECK(secp256k1_xonly_pubkey_parse(CTX, &pubkeys[i], &pubkeys_ser[i*32]));
+        }
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len));
+    }
+    /* Test vector 2 */
+    {
+        size_t n = 2;
+        const unsigned char pubkeys_ser[2*32] = {
+            0x1b, 0x84, 0xc5, 0x56, 0x7b, 0x12, 0x64, 0x40,
+            0x99, 0x5d, 0x3e, 0xd5, 0xaa, 0xba, 0x05, 0x65,
+            0xd7, 0x1e, 0x18, 0x34, 0x60, 0x48, 0x19, 0xff,
+            0x9c, 0x17, 0xf5, 0xe9, 0xd5, 0xdd, 0x07, 0x8f,
+
+            0x46, 0x27, 0x79, 0xad, 0x4a, 0xad, 0x39, 0x51,
+            0x46, 0x14, 0x75, 0x1a, 0x71, 0x08, 0x5f, 0x2f,
+            0x10, 0xe1, 0xc7, 0xa5, 0x93, 0xe4, 0xe0, 0x30,
+            0xef, 0xb5, 0xb8, 0x72, 0x1c, 0xe5, 0x5b, 0x0b,
+        };
+        secp256k1_xonly_pubkey pubkeys[2];
+        const unsigned char msgs32[2*32] = {
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+            0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+
+            0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+            0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+            0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+            0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+        };
+        const unsigned char aggsig[2*32+32] = {
+            0xb0, 0x70, 0xaa, 0xfc, 0xea, 0x43, 0x9a, 0x4f,
+            0x6f, 0x1b, 0xbf, 0xc2, 0xeb, 0x66, 0xd2, 0x9d,
+            0x24, 0xb0, 0xca, 0xb7, 0x4d, 0x6b, 0x74, 0x5c,
+            0x3c, 0xfb, 0x00, 0x9c, 0xc8, 0xfe, 0x4a, 0xa8,
+            0xa3, 0xaf, 0xbd, 0xb4, 0x5a, 0x6a, 0x34, 0xbf,
+            0x7c, 0x8c, 0x00, 0xf1, 0xb6, 0xd7, 0xe7, 0xd3,
+            0x75, 0xb5, 0x45, 0x40, 0xf1, 0x37, 0x16, 0xc8,
+            0x7b, 0x62, 0xe5, 0x1e, 0x2f, 0x4f, 0x22, 0xff,
+            0xbf, 0x89, 0x13, 0xec, 0x53, 0x22, 0x6a, 0x34,
+            0x89, 0x2d, 0x60, 0x25, 0x2a, 0x70, 0x52, 0x61,
+            0x4c, 0xa7, 0x9a, 0xe9, 0x39, 0x98, 0x68, 0x28,
+            0xd8, 0x1d, 0x23, 0x11, 0x95, 0x73, 0x71, 0xad,
+        };
+        size_t aggsig_len = sizeof(aggsig);
+        size_t i;
+        for (i = 0; i < n; ++i) {
+            CHECK(secp256k1_xonly_pubkey_parse(CTX, &pubkeys[i], &pubkeys_ser[i*32]));
+        }
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len));
+    }
+}
+
+static void test_schnorrsig_aggregate_api(void) {
+    size_t n = secp256k1_testrand_int(N_MAX + 1);
+    size_t n_initial = secp256k1_testrand_int(n + 1);
+    size_t n_new = n - n_initial;
+
+    /* Test preparation. */
+    secp256k1_xonly_pubkey pubkeys[N_MAX];
+    unsigned char msgs32[N_MAX*32];
+    unsigned char sigs64[N_MAX*64];
+    unsigned char aggsig[32*(N_MAX + 1)];
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+
+    /* Test body 1: Check API of function aggregate. */
+    {
+        /* Should not accept NULL for aggsig or aggsig length */
+        size_t aggsig_len = sizeof(aggsig);
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggregate(CTX, NULL, &aggsig_len, pubkeys, msgs32, sigs64, n_initial));
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggregate(CTX, aggsig, NULL, pubkeys, msgs32, sigs64, n_initial));
+        /* Should not accept NULL for keys, messages, or signatures if n_initial is not 0 */
+        if (n_initial != 0) {
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, NULL, msgs32, sigs64, n_initial));
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, NULL, sigs64, n_initial));
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, NULL, n_initial));
+        }
+    }
+
+    /* Test body 2: Check API of function inc_aggregate. */
+    {
+        size_t aggsig_len = sizeof(aggsig);
+        CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, sigs64, n_initial));
+        aggsig_len = 32*(n+1);
+        /* Should not accept NULL for aggsig or aggsig length */
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, NULL, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new));
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, NULL, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new));
+        /* Should not accept NULL for keys or messages if n is not 0 */
+        if (n != 0) {
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, NULL, msgs32, &sigs64[n_initial*64], n_initial, n_new));
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, NULL, &sigs64[n_initial*64], n_initial, n_new));
+        }
+        /* Should not accept NULL for new_sigs64 if n_new is not 0 */
+        if (n_new != 0) {
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, NULL, n_initial, n_new));
+        }
+        /* Should not accept overflowing number of sigs. */
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], SIZE_MAX, SIZE_MAX));
+        if (n_initial > 0) {
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, SIZE_MAX));
+        }
+        /* Should reject if aggsig_len is too small. */
+        aggsig_len = 32*n;
+        CHECK(secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new) == 0);
+        aggsig_len = 32*(n+1) - 1;
+        CHECK(secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new) == 0);
+    }
+
+    /* Test body 3: Check API of function aggverify. */
+    {
+        size_t aggsig_len = sizeof(aggsig);
+        CHECK(secp256k1_schnorrsig_inc_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, &sigs64[n_initial*64], n_initial, n_new));
+        /* Should not accept NULL for keys or messages if n is not 0 */
+        if (n != 0) {
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggverify(CTX, NULL, msgs32, n, aggsig, aggsig_len));
+            CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggverify(CTX, pubkeys, NULL, n, aggsig, aggsig_len));
+        }
+        /* Should never accept NULL the aggsig */
+        CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, NULL, aggsig_len));
+        /* Should reject for invalid aggsig_len. */
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len + 1) == 0);
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len - 1) == 0);
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len + 32) == 0);
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len - 32) == 0);
+    }
+}
+
+/* In this test, we make sure that trivial attempts to break
+ * the security of verification do not work. */
+static void test_schnorrsig_aggregate_unforge(void) {
+    secp256k1_xonly_pubkey pubkeys[N_MAX];
+    unsigned char msgs32[N_MAX*32];
+    unsigned char sigs64[N_MAX*64];
+    unsigned char aggsig[32*(N_MAX + 1)];
+
+    size_t n = secp256k1_testrand_int(N_MAX + 1);
+
+    /* Test 1: We fix a set of n messages and compute
+     * a random aggsig for them. This should not verify. */
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+    {
+        size_t aggsig_len = sizeof(aggsig);
+        size_t i;
+        /* Sample aggsig randomly */
+        for (i = 0; i < n + 1; ++i) {
+            secp256k1_testrand256(&aggsig[i*32]);
+        }
+        /* Make sure that it does not verify */
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len) == 0);
+    }
+
+    /* Test 2: We fix a set of n messages and compute valid
+     * signatures for all but one. The resulting aggregate signature
+     * should not verify. */
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+    if (n > 0) {
+        size_t aggsig_len = sizeof(aggsig);
+        /* Replace a randomly chosen real sig with a random one. */
+        size_t k = secp256k1_testrand_int(n);
+        secp256k1_testrand256(&sigs64[k*64]);
+        secp256k1_testrand256(&sigs64[k*64+32]);
+        /* Aggregate the n signatures */
+        CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, sigs64, n));
+        /* Make sure the result does not verify */
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len) == 0);
+    }
+
+    /* Test 3: We generate a valid aggregate signature and then
+     * change one of the messages. This should not verify. */
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+    if (n > 0) {
+        size_t aggsig_len = sizeof(aggsig);
+        size_t k;
+        /* Aggregate the n signatures */
+        CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, sigs64, n));
+        /* Change one of the messages */
+        k = secp256k1_testrand_int(32*n);
+        msgs32[k] = msgs32[k]^0xff;
+        /* Make sure the result does not verify */
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len) == 0);
+    }
+}
+
+/* In this test, we make sure that the algorithms properly reject
+ * for overflowing and non parseable values. */
+static void test_schnorrsig_aggregate_overflow(void) {
+    secp256k1_xonly_pubkey pubkeys[N_MAX];
+    unsigned char msgs32[N_MAX*32];
+    unsigned char sigs64[N_MAX*64];
+    unsigned char aggsig[32*(N_MAX + 1)];
+    size_t n = secp256k1_testrand_int(N_MAX + 1);
+
+    /* We check that verification returns 0 if the s in aggsig overflows. */
+    test_schnorrsig_aggregate_input_helper(pubkeys, msgs32, sigs64, n);
+    {
+        size_t aggsig_len = sizeof(aggsig);
+        /* Aggregate */
+        CHECK(secp256k1_schnorrsig_aggregate(CTX, aggsig, &aggsig_len, pubkeys, msgs32, sigs64, n));
+        /* Make s in the aggsig overflow */
+        memset(&aggsig[n*32], 0xFF, 32);
+        /* Should not verify */
+        CHECK(secp256k1_schnorrsig_aggverify(CTX, pubkeys, msgs32, n, aggsig, aggsig_len) == 0);
+    }
+}
+
+static void run_schnorrsig_halfagg_tests(void) {
+    int i;
+
+    test_schnorrsig_sha256_tagged_aggregate();
+    test_schnorrsig_aggverify_spec_vectors();
+
+    for (i = 0; i < COUNT; i++) {
+        test_schnorrsig_aggregate();
+        test_schnorrsig_aggregate_api();
+        test_schnorrsig_aggregate_unforge();
+        test_schnorrsig_aggregate_overflow();
+    }
+}
+
+#undef N_MAX
+
+#endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -873,6 +873,10 @@ static int secp256k1_ge_parse_ext(secp256k1_ge* ge, const unsigned char *in33) {
 # include "modules/schnorrsig/main_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_SCHNORRSIG_HALFAGG
+# include "modules/schnorrsig_halfagg/main_impl.h"
+#endif
+
 #ifdef ENABLE_MODULE_ELLSWIFT
 # include "modules/ellswift/main_impl.h"
 #endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -7446,6 +7446,10 @@ static void run_ecdsa_wycheproof(void) {
     test_ecdsa_wycheproof();
 }
 
+#ifdef ENABLE_MODULE_SCHNORRSIG_HALFAGG
+# include "modules/schnorrsig_halfagg/tests_impl.h"
+#endif
+
 #ifdef ENABLE_MODULE_BPPP
 # include "modules/bppp/tests_impl.h"
 #endif
@@ -7817,6 +7821,10 @@ int main(int argc, char **argv) {
 
     /* EC key arithmetic test */
     run_eckey_negate_test();
+
+#ifdef ENABLE_MODULE_SCHNORRSIG_HALFAGG
+    run_schnorrsig_halfagg_tests();
+#endif
 
 #ifdef ENABLE_MODULE_BPPP
     run_bppp_tests();


### PR DESCRIPTION
Revisited PR #130 by jonasnick.
I am happy to hear your thoughts.

**Summary of changes compared to #130:** 

- Address comments from rustyrussell 
- Use tagged hash
- Compute hashes with common prefix by copying midstate
- Allow Incremental Aggregation and make code consistent with the [draft spec](https://github.com/BlockstreamResearch/cross-input-aggregation/blob/master/half-aggregation.mediawiki)