### PR TITLE
bppp: Fix test for invalid sign byte again

### DIFF
--- a/src/modules/bppp/tests_impl.h
+++ b/src/modules/bppp/tests_impl.h
@@ -257,10 +257,8 @@ static void test_serialize_two_points(void) {
         random_group_element_test(&R);
         secp256k1_bppp_serialize_points(buf, &X, &R);
 
-        buf[0] = 4 + (unsigned char)secp256k1_testrandi64(0, 253);
-        /* Assert that buf[0] is actually invalid. */
-        CHECK(buf[0] != 0x02 && buf[0] != 0x03);
-
+        /* buf is valid if 0 <= buf[0] < 4. */
+        buf[0] = (unsigned char)secp256k1_testrandi64(4, 255);
         CHECK(!secp256k1_bppp_parse_one_of_points(&X_tmp, buf, 0));
         CHECK(!secp256k1_bppp_parse_one_of_points(&R_tmp, buf, 0));
     }


### PR DESCRIPTION
The first byte provided to secp256k1_bppp_parse_one_of_points is allowed to be 0, 1, 2, or 3 since it encodes the Y coordinate of two points. In a previous fix we wrongly assumed it can only be 2 or 3.