### PR TITLE
surjectionproof: remove unused include

### DIFF
--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -9,10 +9,6 @@
 #include <assert.h>
 #include <string.h>
 
-#if defined HAVE_CONFIG_H
-#include "../../libsecp256k1-config.h"
-#endif
-
 #include "../../../include/secp256k1_rangeproof.h"
 #include "../../../include/secp256k1_surjectionproof.h"
 #include "../rangeproof/borromean.h"


### PR DESCRIPTION
Following the merge of b627ba7050b608e869515a8ef622d71bf8c13b54 from upstream, this include should have been deleted as well.