### PR TITLE
Avoid using out-of-bounds field elements (in impossible cases)

### DIFF
--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -222,7 +222,9 @@ static int secp256k1_generator_generate_internal(const secp256k1_context* ctx, s
     secp256k1_sha256_write(&sha256, prefix1, 16);
     secp256k1_sha256_write(&sha256, key32, 32);
     secp256k1_sha256_finalize(&sha256, b32);
-    ret &= secp256k1_fe_set_b32_limit(&t, b32);
+    if (secp256k1_fe_set_b32_limit(&t, b32) == 0) {
+        return 0;
+    }
     shallue_van_de_woestijne(&add, &t);
     if (blind32) {
         secp256k1_gej_add_ge(&accum, &accum, &add);
@@ -234,7 +236,9 @@ static int secp256k1_generator_generate_internal(const secp256k1_context* ctx, s
     secp256k1_sha256_write(&sha256, prefix2, 16);
     secp256k1_sha256_write(&sha256, key32, 32);
     secp256k1_sha256_finalize(&sha256, b32);
-    ret &= secp256k1_fe_set_b32_limit(&t, b32);
+    if (secp256k1_fe_set_b32_limit(&t, b32) == 0) {
+        return 0;
+    }
     shallue_van_de_woestijne(&add, &t);
     secp256k1_gej_add_ge(&accum, &accum, &add);
 


### PR DESCRIPTION
secp256k1_fe_set_b32_limit says that when it returns 0, one is not allowed to use the resulting output value.

This refactors the code so that 0 is returned early (indicating failure) in cases where sha256 would output an out-of-bounds hash value. This makes secp256k1_generator_generate_internal variable-time in its "t" argument, but this not a problem because this value is public in applications.

Note: This situation is cryptographically impossible to occur.

Alternative to #282. cc @roconnor-blockstream What do you think? 