### PR TITLE
doc: fix sage code for deriving alternative generator H

### DIFF
--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -24,7 +24,7 @@
     import hashlib
     F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
     G = '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
-    H = EllipticCurve ([F (0), F (7)]).lift_x(F(int(hashlib.sha256(G.decode('hex')).hexdigest(),16)))
+    H = EllipticCurve ([F (0), F (7)]).lift_x(F(int(hashlib.sha256(bytes.fromhex(G)).hexdigest(),16)))
     print('%x %x' % H.xy())
  */
 static const secp256k1_generator secp256k1_generator_h_internal = {{


### PR DESCRIPTION
The line calculating H (in particular, the expression `G.decode('hex')`) fails with the following error message on Sage 9.5:

```
AttributeError: 'str' object has no attribute 'decode'
```

Fix that by converting the hex-string to bytes using `bytes.fromhex`.

(Noticed while reviewing https://github.com/bitcoin/bitcoin/pull/30048 which picks this code snippet comment up.)