### PR TITLE
Musig: Minor comment corrections

### DIFF
--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -129,7 +129,7 @@ static void secp256k1_musig_keyaggcoef_sha256(secp256k1_sha256 *sha) {
 }
 
 /* Compute KeyAgg coefficient which is constant 1 for the second pubkey and
- * otherwise tagged_hash(pk_hash, x) where pk_hash is the hash of public keys.
+ * otherwise tagged_hash(pk_hash, pk) where pk_hash is the hash of public keys.
  * second_pk is the point at infinity in case there is no second_pk. Assumes
  * that pk is not the point at infinity and that the Y-coordinates of pk and
  * second_pk are normalized. */
@@ -162,7 +162,7 @@ static void secp256k1_musig_keyaggcoef_internal(secp256k1_scalar *r, const unsig
     }
 }
 
-/* Assumes both field elements x and second_pk_x are normalized. */
+/* Assumes both field elements pk_x and second_pk_x are normalized. */
 static void secp256k1_musig_keyaggcoef(secp256k1_scalar *r, const secp256k1_keyagg_cache_internal *cache_i, secp256k1_ge *pk) {
     secp256k1_musig_keyaggcoef_internal(r, cache_i->pk_hash, pk, &cache_i->second_pk);
 }

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -633,8 +633,8 @@ int secp256k1_musig_partial_sig_verify(const secp256k1_context* ctx, const secp2
         return 0;
     }
 
-    /* Compute "effective" nonce rj = aggnonce[0] + b*aggnonce[1] */
-    /* TODO: use multiexp to compute -s*G + e*mu*pubkey + aggnonce[0] + b*aggnonce[1] */
+    /* Compute "effective" nonce rj = pubnonce[0] + b*pubnonce[1] */
+    /* TODO: use multiexp to compute -s*G + e*mu*pubkey + pubnonce[0] + b*pubnonce[1] */
     if (!secp256k1_musig_pubnonce_load(ctx, nonce_pt, pubnonce)) {
         return 0;
     }


### PR DESCRIPTION
Changes:
- PartialSigVerify mistakenly refers to `pubnonce` as `aggnonce`.
    - _Edit:_ Just noticed that this correction was already pointed out here: https://github.com/bitcoin-core/secp256k1/pull/1479#discussion_r1731398318
- KeyAgg comments inconsistently use both `x` and `pk` to refer to the public key argument. Updated to use only `pk`.