### PR TITLE
ci: Backport MSan fixes for ctime_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,11 +556,18 @@ jobs:
       matrix:
         configuration:
           - env_vars:
+              CTIMETESTS: 'yes'
               CFLAGS: '-fsanitize=memory -fsanitize-recover=memory -g'
           - env_vars:
               ECMULTGENPRECISION: 2
               ECMULTWINDOW: 2
+              CTIMETESTS: 'yes'
               CFLAGS: '-fsanitize=memory -fsanitize-recover=memory -g -O3'
+          - env_vars:
+              # -fsanitize-memory-param-retval is clang's default, but our build system disables it
+              # when ctime_tests when enabled.
+              CFLAGS: '-fsanitize=memory -fsanitize-recover=memory -fsanitize-memory-param-retval -g'
+              CTIMETESTS: 'no'
 
     env:
       ECDH: 'yes'
@@ -576,7 +583,6 @@ jobs:
       ECDSAADAPTOR: 'yes'
       BPPP: 'yes'
       SCHNORRSIG_HALFAGG: 'yes'
-      CTIMETESTS: 'yes'
       CC: 'clang'
       SECP256K1_TEST_ITERS: 32
       ASM: 'no'

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -45,6 +45,18 @@ fi
 AC_MSG_RESULT($has_valgrind)
 ])
 
+AC_DEFUN([SECP_MSAN_CHECK], [
+AC_MSG_CHECKING(whether MemorySanitizer is enabled)
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+  #if defined(__has_feature)
+  #  if __has_feature(memory_sanitizer)
+  #    error "MemorySanitizer is enabled."
+  #  endif
+  #endif
+  ]])], [msan_enabled=no], [msan_enabled=yes])
+AC_MSG_RESULT([$msan_enabled])
+])
+
 dnl SECP_TRY_APPEND_CFLAGS(flags, VAR)
 dnl Append flags to VAR if CC accepts them.
 AC_DEFUN([SECP_TRY_APPEND_CFLAGS], [

--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,20 @@ if test x"$enable_ctime_tests" = x"auto"; then
     enable_ctime_tests=$enable_valgrind
 fi
 
+print_msan_notice=no
+if test x"$enable_ctime_tests" = x"yes" && test x"$GCC" = x"yes"; then
+  SECP_MSAN_CHECK
+  # MSan on Clang >=16 reports unitialized memory in function parameters and return values, even if
+  # the uninitalized variable is never actually "used". This is called "eager" checking, and it's
+  # sounds like good idea for normal use of MSan. However, it yields many false positives in the
+  # ctime_tests because many return values depend on secret (i.e., "uninitialized") values, and
+  # we're only interested in detecting branches (which count as "uses") on secret data.
+  if test x"$msan_enabled" = x"yes"; then
+    SECP_TRY_APPEND_CFLAGS([-fno-sanitize-memory-param-retval], SECP_CFLAGS)
+    print_msan_notice=yes
+  fi
+fi
+
 if test x"$enable_coverage" = x"yes"; then
     SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DCOVERAGE=1"
     SECP_CFLAGS="-O0 --coverage $SECP_CFLAGS"
@@ -660,9 +674,16 @@ if test x"$set_widemul" != xauto; then
 echo "  wide multiplication       = $set_widemul"
 fi
 echo
-echo "  valgrind                  = $enable_valgrind"
-echo "  CC                        = $CC"
-echo "  CPPFLAGS                  = $CPPFLAGS"
-echo "  SECP_CFLAGS               = $SECP_CFLAGS"
-echo "  CFLAGS                    = $CFLAGS"
-echo "  LDFLAGS                   = $LDFLAGS"
+echo "  valgrind                = $enable_valgrind"
+echo "  CC                      = $CC"
+echo "  CPPFLAGS                = $CPPFLAGS"
+echo "  SECP_CFLAGS             = $SECP_CFLAGS"
+echo "  CFLAGS                  = $CFLAGS"
+echo "  LDFLAGS                 = $LDFLAGS"
+
+if test x"$print_msan_notice" = x"yes"; then
+  echo
+  echo "Note:"
+  echo "  MemorySanitizer detected, tried to add -fno-sanitize-memory-param-retval to SECP_CFLAGS"
+  echo "  to avoid false positives in ctime_tests. Pass --disable-ctime-tests to avoid this."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -556,12 +556,7 @@ fi
 ### Check for --enable-experimental if necessary
 ###
 
-if test x"$enable_experimental" = x"yes"; then
-  AC_MSG_NOTICE([******])
-  AC_MSG_NOTICE([WARNING: experimental build])
-  AC_MSG_NOTICE([Experimental features do not have stable APIs or properties, and may not be safe for production use.])
-  AC_MSG_NOTICE([******])
-else
+if test x"$enable_experimental" = x"no"; then
   # The order of the following tests matters. If the user enables a dependent
   # module (which automatically enables the module dependencies) we want to
   # print an error for the dependent module, not the module dependency. Hence,
@@ -686,4 +681,11 @@ if test x"$print_msan_notice" = x"yes"; then
   echo "Note:"
   echo "  MemorySanitizer detected, tried to add -fno-sanitize-memory-param-retval to SECP_CFLAGS"
   echo "  to avoid false positives in ctime_tests. Pass --disable-ctime-tests to avoid this."
+fi
+
+if test x"$enable_experimental" = x"yes"; then
+  echo
+  echo "WARNING: Experimental build"
+  echo "  Experimental features do not have stable APIs or properties, and may not be safe for"
+  echo "  production use."
 fi


### PR DESCRIPTION
Cherry-picked the upstream fixes from bitcoin-core/secp256k1#1517 to align behaviour here and silence the false 'use-of-uninitialized-value' reports in ctime_tests under Clang ≥16.

#### Result:
- `ctime_tests` is clean under MSan.
- Other tests are unchanged.
- No API or behaviour changes.

#### Commits cherry-picked: 
- [55e5d975db9a641bcbeffcc3fc086e54d322fe26](https://github.com/bitcoin-core/secp256k1/pull/1517/commits/55e5d975db9a641bcbeffcc3fc086e54d322fe26),
- [e1bef0961c53b23dbaf35f5fa87149a1aadfad37](https://github.com/bitcoin-core/secp256k1/pull/1517/commits/e1bef0961c53b23dbaf35f5fa87149a1aadfad37),
- [ebfb82ee2f8c15ae6129932380b1dfb0942ea35a](https://github.com/bitcoin-core/secp256k1/pull/1517/commits/ebfb82ee2f8c15ae6129932380b1dfb0942ea35a)

#### References:
Upstream: https://github.com/bitcoin-core/secp256k1/pull/1517